### PR TITLE
Compiler bugfix, define binary data type, bugfix when initilizing MarchingCubes

### DIFF
--- a/src/lib/marching_cubes_tsdf_octree.cpp
+++ b/src/lib/marching_cubes_tsdf_octree.cpp
@@ -76,6 +76,10 @@ cpu_tsdf::MarchingCubesTSDFOctree::setInputTSDF (cpu_tsdf::TSDFVolumeOctree::Con
   float iso_z = 0;
   PCL_INFO ("iso_x = %f, iso_y = %f, iso_z = %f\n", iso_x, iso_y, iso_z);
   setIsoLevel (std::min (iso_x, std::min (iso_y, iso_z)));
+  // Initialize size_voxel_ which is needed by pcl::MarchingCubes::createSurface
+  // If left uninitialized createSurface creates erroneous coordinates for the mesh
+  getBoundingBox();
+  size_voxel_ = (upper_boundary_ - lower_boundary_)* Eigen::Array3f(res_x_, res_y_, res_z_).inverse();
 }
 
 void

--- a/src/lib/tsdf_volume_octree.cpp
+++ b/src/lib/tsdf_volume_octree.cpp
@@ -77,7 +77,7 @@ cpu_tsdf::TSDFVolumeOctree::TSDFVolumeOctree()
   , weight_by_variance_ (false)
   , integrate_color_ (false)
   , color_mode_ ("RGB")
-  , use_trilinear_interpolation_ (false)
+  , use_trilinear_interpolation_ (true)
   , num_random_splits_ (1)
 {
   // Global transform

--- a/src/lib/tsdf_volume_octree.cpp
+++ b/src/lib/tsdf_volume_octree.cpp
@@ -222,7 +222,7 @@ cpu_tsdf::TSDFVolumeOctree::reset ()
 void
 cpu_tsdf::TSDFVolumeOctree::save (const std::string &filename) const
 {
-  std::ofstream f (filename.c_str ());
+  std::ofstream f (filename.c_str (), std::ios::binary);
   f << "# TSDFVolumeOctree Meta Information" << endl;
   f.precision (16);
 
@@ -248,7 +248,7 @@ cpu_tsdf::TSDFVolumeOctree::save (const std::string &filename) const
 void
 cpu_tsdf::TSDFVolumeOctree::load (const std::string &filename)
 {
-  std::ifstream f (filename.c_str ());
+  std::ifstream f (filename.c_str (), std::ios::binary);
   char header[1024];
   f.getline (header, 1024);
   f >> xres_; f >> yres_; f >> zres_; 

--- a/src/lib/tsdf_volume_octree.cpp
+++ b/src/lib/tsdf_volume_octree.cpp
@@ -212,7 +212,7 @@ cpu_tsdf::TSDFVolumeOctree::reset ()
   // Initialize to 0 weight, -1 distance
   std::vector<cpu_tsdf::OctreeNode::Ptr> leaves; octree_->getLeaves (leaves);
 #pragma omp parallel for
-  for (size_t i = 0; i < leaves.size (); i++)
+  for (int64_t i = 0; i < leaves.size (); i++)
   {
     leaves[i]->setData (-1, 0);
   }
@@ -288,7 +288,7 @@ cpu_tsdf::TSDFVolumeOctree::renderView (const Eigen::Affine3d &trans, int downsa
   cloud->is_dense = false;
   float min_step = max_dist_neg_ * 3/4.;
 #pragma omp parallel for
-  for (size_t i = 0; i < cloud->size (); ++i)
+  for (int64_t i = 0; i < cloud->size (); ++i)
   {
     size_t x = i % new_width;
     size_t y = i / new_width;
@@ -433,7 +433,7 @@ cpu_tsdf::TSDFVolumeOctree::renderColoredView (const Eigen::Affine3d &trans, int
   pcl::PointCloud<pcl::PointXYZRGBNormal>::Ptr colored (new pcl::PointCloud<pcl::PointXYZRGBNormal> (grayscale->width, grayscale->height));
   colored->is_dense = false;
 #pragma omp parallel for
-  for (size_t i = 0; i < colored->size (); i++)
+  for (int64_t i = 0; i < colored->size (); i++)
   {
     pcl::PointXYZRGBNormal &pt = colored->at (i);
     pt.getVector3fMap () = grayscale->at (i).getVector3fMap ();


### PR DESCRIPTION
When using the code I found some things which were not working for me and so I figured to share my fixes with you:
- Fixed compiler erros when compiling the code because OMP expects its for-loop iterators to be of a signed data-type
- explicitly defined binary-data types for saving and loading the tsdf binarys. If not defined this might work for linux systems. However, on Windows this created runtime errors when reading the filestream
- the size_voxel variable of the pcl::MarchingCubes was not initialized. thus, leading to mesh vertices with extremely unreasonable high values