### PR TITLE
executables that depend on PCL visualisation are only build if PCL wa…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 find_package(PCL 1.7 QUIET REQUIRED)
 
+if (NOT PCL_VISUALIZATION_FOUND)
+  message("PCL_VISUALIZATION was not found. Skip building some executables.")
+endif()
+
 include_directories(${PCL_INCLUDE_DIRS})
 link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
@@ -53,17 +57,19 @@ add_executable (tsdf2mesh src/prog/tsdf2mesh.cpp)
 target_link_libraries(tsdf2mesh ${PCL_LIBRARIES} cpu_tsdf)
 install(TARGETS tsdf2mesh DESTINATION bin)
 
-if (APPLE)
-  add_executable (integrate MACOSX_BUNDLE src/prog/integrate.cpp)
-else(APPLE)
-  add_executable (integrate src/prog/integrate.cpp)
-endif(APPLE)
-target_link_libraries(integrate ${PCL_LIBRARIES} cpu_tsdf ${Boost_PROGRAM_OPTIONS_LIBRARY})
-install(TARGETS integrate DESTINATION bin)
+if (PCL_VISUALIZATION_FOUND)
+  if (APPLE)
+    add_executable (integrate MACOSX_BUNDLE src/prog/integrate.cpp)
+  else(APPLE)
+    add_executable (integrate src/prog/integrate.cpp)
+  endif(APPLE)
+  target_link_libraries(integrate ${PCL_LIBRARIES} cpu_tsdf ${Boost_PROGRAM_OPTIONS_LIBRARY})
+  install(TARGETS integrate DESTINATION bin)
 
-add_executable (get_intrinsics src/prog/get_intrinsics.cpp)
-target_link_libraries(get_intrinsics ${PCL_LIBRARIES} ${Boost_PROGRAM_OPTIONS_LIBRARY})
-install(TARGETS get_intrinsics DESTINATION bin)
+  add_executable (get_intrinsics src/prog/get_intrinsics.cpp)
+  target_link_libraries(get_intrinsics ${PCL_LIBRARIES} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+  install(TARGETS get_intrinsics DESTINATION bin)
+endif (PCL_VISUALIZATION_FOUND)
 
 # Install the Header files preserving the directory
 set(HEADER_FILES include/cpu_tsdf/impl/tsdf_volume_octree.hpp


### PR DESCRIPTION
fixed cmake to build some executables only if PCL was build with visualisations. PCL visualisations requires VTK, and therefore on some systems PCL is build without visualisations.