### PR TITLE
pcl-compatibility: replaced pcl_isnan by std::isnan

### DIFF
--- a/include/cpu_tsdf/impl/tsdf_volume_octree.hpp
+++ b/include/cpu_tsdf/impl/tsdf_volume_octree.hpp
@@ -61,7 +61,7 @@ cpu_tsdf::TSDFVolumeOctree::integrateCloud (
     for (size_t v = 0; v < cloud.height; v += px_step)
     {
       const PointT &pt_surface_orig = cloud (u, v);
-      if (pcl_isnan (pt_surface_orig.z))
+      if (std::isnan (pt_surface_orig.z))
         continue;
       // Look at surroundings
       int nstep = 0;
@@ -149,7 +149,7 @@ cpu_tsdf::TSDFVolumeOctree::updateVoxel (
   if (!reprojectPoint (v_g, u, v))
     return (0); // No observation
   const PointT &pt = cloud (u,v);
-  if (pcl_isnan (pt.z))
+  if (std::isnan (pt.z))
     return (0); // No observation
    // if (pt.z >= max_sensor_dist_) // We want to let empty points be empty, even at noisy readings
    //   return (0);

--- a/src/lib/marching_cubes_tsdf_octree.cpp
+++ b/src/lib/marching_cubes_tsdf_octree.cpp
@@ -149,28 +149,28 @@ cpu_tsdf::MarchingCubesTSDFOctree::getValidNeighborList1D (std::vector<float> &l
   leaf = std::vector<float> (8, 0.0f);
 
   leaf[0] = getGridValue (index3d);
-  if (pcl_isnan (leaf[0]))
+  if (std::isnan (leaf[0]))
     return (false);
   leaf[1] = getGridValue (index3d + Eigen::Vector3i (1, 0, 0));
-  if (pcl_isnan (leaf[1]))
+  if (std::isnan (leaf[1]))
     return (false);
   leaf[2] = getGridValue (index3d + Eigen::Vector3i (1, 0, 1));
-  if (pcl_isnan (leaf[2]))
+  if (std::isnan (leaf[2]))
     return (false);
   leaf[3] = getGridValue (index3d + Eigen::Vector3i (0, 0, 1));
-  if (pcl_isnan (leaf[3]))
+  if (std::isnan (leaf[3]))
     return (false);
   leaf[4] = getGridValue (index3d + Eigen::Vector3i (0, 1, 0));
-  if (pcl_isnan (leaf[4]))
+  if (std::isnan (leaf[4]))
     return (false);
   leaf[5] = getGridValue (index3d + Eigen::Vector3i (1, 1, 0));
-  if (pcl_isnan (leaf[5]))
+  if (std::isnan (leaf[5]))
     return (false);
   leaf[6] = getGridValue (index3d + Eigen::Vector3i (1, 1, 1));
-  if (pcl_isnan (leaf[6]))
+  if (std::isnan (leaf[6]))
     return (false);
   leaf[7] = getGridValue (index3d + Eigen::Vector3i (0, 1, 1));
-  if (pcl_isnan (leaf[7]))
+  if (std::isnan (leaf[7]))
     return (false);
   return (true);
 

--- a/src/lib/octree.cpp
+++ b/src/lib/octree.cpp
@@ -628,7 +628,7 @@ cpu_tsdf::Octree::getLeaves (std::vector<OctreeNode::Ptr> &leaves, float max_siz
 const cpu_tsdf::OctreeNode*
 cpu_tsdf::Octree::getContainingVoxel (float x, float y, float z, float min_size) const
 {
-  if (pcl_isnan (z) || std::fabs (x) > size_x_/2 || std::fabs (y) > size_y_/2 || std::fabs (z) > size_z_/2)
+  if (std::isnan (z) || std::fabs (x) > size_x_/2 || std::fabs (y) > size_y_/2 || std::fabs (z) > size_z_/2)
     return (NULL);
   return (root_->getContainingVoxel (x, y, z, min_size));
 }
@@ -637,7 +637,7 @@ cpu_tsdf::Octree::getContainingVoxel (float x, float y, float z, float min_size)
 cpu_tsdf::OctreeNode*
 cpu_tsdf::Octree::getContainingVoxel (float x, float y, float z, float min_size)
 {
-  if (pcl_isnan (z) || std::fabs (x) > size_x_/2 || std::fabs (y) > size_y_/2 || std::fabs (z) > size_z_/2)
+  if (std::isnan (z) || std::fabs (x) > size_x_/2 || std::fabs (y) > size_y_/2 || std::fabs (z) > size_z_/2)
     return (NULL);
   return (root_->getContainingVoxel (x, y, z, min_size));
 }

--- a/src/lib/tsdf_volume_octree.cpp
+++ b/src/lib/tsdf_volume_octree.cpp
@@ -382,7 +382,7 @@ cpu_tsdf::TSDFVolumeOctree::renderView (const Eigen::Affine3d &trans, int downsa
       last_d = getTSDFValue (trans.translation ().cast<float> () + (tprev) * du, 
                              &has_data);
       d = getTSDFValue (trans.translation ().cast<float> () + tcurr * du, &has_data);
-      if (!has_data || pcl_isnan (d) || pcl_isnan (last_d))
+      if (!has_data || std::isnan (d) || std::isnan (last_d))
       {
         pt.x = pt.y = pt.z = std::numeric_limits<float>::quiet_NaN ();
       }
@@ -438,7 +438,7 @@ cpu_tsdf::TSDFVolumeOctree::renderColoredView (const Eigen::Affine3d &trans, int
     pcl::PointXYZRGBNormal &pt = colored->at (i);
     pt.getVector3fMap () = grayscale->at (i).getVector3fMap ();
     pt.getNormalVector3fMap () = grayscale->at (i).getNormalVector3fMap ();
-    if (pcl_isnan (pt.z))
+    if (std::isnan (pt.z))
       continue;
     Eigen::Vector3f v_t = trans.cast<float> () * pt.getVector3fMap ();
     const cpu_tsdf::OctreeNode* voxel = octree_->getContainingVoxel (v_t (0), v_t (1), v_t (2));

--- a/src/prog/get_intrinsics.cpp
+++ b/src/prog/get_intrinsics.cpp
@@ -74,7 +74,7 @@ getIntrinsics (const pcl::PointCloud<pcl::PointXYZ> &cloud,
     for (int y = 0; y < cloud.height; y++)
     {
       const pcl::PointXYZ &pt = cloud (x,y);
-      if (pcl_isnan (pt.x) || pcl_isnan (pt.y) || pcl_isnan (pt.z) || (pt.x == 0) || (pt.y == 0))
+      if (std::isnan (pt.x) || std::isnan (pt.y) || std::isnan (pt.z) || (pt.x == 0) || (pt.y == 0))
         continue;
       if (pt.x > maxX) maxX = pt.x;
       if (pt.y > maxY) maxY = pt.y;

--- a/src/prog/integrate.cpp
+++ b/src/prog/integrate.cpp
@@ -218,7 +218,7 @@ reprojectPoint (const pcl::PointXYZRGBA &pt, int &u, int &v)
 {
   u = (pt.x * focal_length_x_ / pt.z) + principal_point_x_;
   v = (pt.y * focal_length_y_ / pt.z) + principal_point_y_;
-  return (!pcl_isnan (pt.z) && pt.z > 0 && u >= 0 && u < width_ && v >= 0 && v < height_);
+  return (!std::isnan (pt.z) && pt.z > 0 && u >= 0 && u < width_ && v >= 0 && v < height_);
 }
 
 std::string getSharedPrefix (const std::vector<std::string> &files)
@@ -602,17 +602,17 @@ main (int argc, char** argv)
       for (size_t j = 0; j < cloud->size (); j++)
       {
         const pcl::PointXYZRGBA &pt = cloud->at (j);
-        if (verbose && !pcl_isnan (pt.z))
+        if (verbose && !std::isnan (pt.z))
           nonnan_original++;
         int u, v;
         if (reprojectPoint (pt, u, v))
         {
           pcl::PointXYZRGBA &pt_old = (*cloud_organized) (u, v);
-          if (pcl_isnan (pt_old.z) || (pt_old.z > pt.z))
+          if (std::isnan (pt_old.z) || (pt_old.z > pt.z))
           {
             if (verbose)
             {
-              if (pcl_isnan (pt_old.z))
+              if (std::isnan (pt_old.z))
                 nonnan_new++;
               if (pt.x < min_x) min_x = pt.x;
               if (pt.y < min_y) min_y = pt.y;
@@ -651,7 +651,7 @@ main (int argc, char** argv)
       pcl::PointCloud<pcl::PointXYZRGBA> cloud_unorganized;
       for (size_t i = 0; i < cloud_organized->size (); i++)
       {
-        if (!pcl_isnan (cloud_organized->at (i).z))
+        if (!std::isnan (cloud_organized->at (i).z))
           cloud_unorganized.push_back (cloud_organized->at (i));
       }
       pcl::transformPointCloud (cloud_unorganized, cloud_unorganized, pose_rel_to_first_frame);


### PR DESCRIPTION
PCL compatibility: Since PCL 1.10.0 the function "pcl_isnan" is not defined anymore and can be safely replaced by std::isnan